### PR TITLE
Fix memory leak (?) causing majority of spell lag

### DIFF
--- a/in-game-lang.rkt
+++ b/in-game-lang.rkt
@@ -177,7 +177,7 @@
   (+ (by-z) (at-z)))
 
 
-(define (codespells-basic-lang) 
+(define codespells-basic-lang (let ()
   (local-require 2htdp/image)
 
   (define (axis #:up [up-c 'green]
@@ -327,6 +327,6 @@
   ;TODO: Make append-rune-langs take the language of the first one?  #:name param??
   (struct-copy rune-lang
                augmented-language
-               [name 'codespells-server/in-game-lang]))
+               [name 'codespells-server/in-game-lang])))
 
 ;End in-world lang stuff

--- a/lang.rkt
+++ b/lang.rkt
@@ -131,9 +131,9 @@
     (rune-surface-height 750)
     (spell-runner
      (identity ;rune-saver
-      (rune-injector (codespells-basic-lang)
-                     ;(demo-editor (codespells-basic-lang))
-                     (rune-surface-component (codespells-basic-lang))
+      (rune-injector codespells-basic-lang
+                     ;(demo-editor codespells-basic-lang)
+                     (rune-surface-component codespells-basic-lang)
                      ))))))
 
 
@@ -187,7 +187,7 @@
 
 
 		       (datum->html 
-			 (codespells-basic-lang)
+			 codespells-basic-lang
 			 result))
 
 		 (card (card-body (card-text (~v result)))))))


### PR DESCRIPTION
I realize you probably have plenty of work on this repo on local right now as you prep for the first build, just wanted to toss this fix your way. Feel free to just close this PR and implement the fix yourself if needed.

Reconstructing the rune language every time a spell is evaluated causes steadily increasing lag. On my machine, testing via POST to /eval-spell?lang=codespells-server/in-game-lang, response time started at around 200ms and seemed to increase at a rate of about 20ms/5req as new rune-langs are allocated and copied repeatedly. I strongly suspect this is what's causing most if not all of the in-game spell lag.

By only defining once, the entire rest of the logic takes only 4-5ms even for complex spells. I'd expect near-instant spell effects resulting from this.